### PR TITLE
Get decorators working with a small React Native example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "babel-plugin-transform-decorators-legacy",
+  "version": "1.0.0",
   "main": "lib",
   "license": "MIT",
   "repository": {
@@ -12,7 +13,9 @@
     "babel-preset-es2015": "^6.1.18"
   },
   "dependencies": {
-    "babel-runtime": "^6.2.0"
+    "babel-plugin-syntax-decorators": "^6.1.18",
+    "babel-runtime": "^6.2.0",
+    "babel-template": "^6.3.0"
   },
   "scripts": {
     "build": "babel src -d lib",

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const buildClassDecorator = template(`
 `);
 
 const buildPropertyDecorator = template(`
-  DECORATOR(TARGET, PROPERTY, DESC = INNER) || DESC;
+  DESC = (DECORATOR(TARGET, PROPERTY, DESC = INNER) || DESC);
 `);
 
 const buildClassPrototype = template(`


### PR DESCRIPTION
I made a small React Native project using RN 0.16-rc, which includes Babel 6. Gist of the code is [here](https://gist.github.com/ide/9141ad48b76f2c85ce43) and required some patches to RN's packager as well as deleting .babelrc files from Redux and React Redux, for anyone who wants to test it themselves. The `@connect` class decorator and `@autobind` method decorator both work now. 
