### PR TITLE
Initialize class property that has no initializer with this.prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -222,9 +222,10 @@ export default function({types: t}){
             if (t.isClassProperty(node, {static: false})){
                 let descriptor = path.scope.generateDeclaredUidIdentifier('descriptor');
 
-                const initializer = node.value ?
-                        t.functionExpression(null, [], t.blockStatement([t.returnStatement(node.value)])) :
-                        t.nullLiteral();
+                const initializerValue = node.value ?
+                    node.value :
+                    t.memberExpression(t.thisExpression(), t.identifier(property.value));
+                const initializer = t.functionExpression(null, [], t.blockStatement([t.returnStatement(initializerValue)]));
                 node.value = t.callExpression(ensureInitializerWarning(path, state), [descriptor, t.thisExpression()]);
 
                 acc = acc.concat([

--- a/test/index.js
+++ b/test/index.js
@@ -637,6 +637,25 @@ describe('decorators', function(){
                 let inst = new Example();
                 expect(inst).to.have.ownProperty('prop');
                 expect(inst.prop).to.be.undefined;
+                expect(Object.getOwnPropertyDescriptor(inst, 'prop').writable).to.be.true;
+            });
+
+            it('should support decorating properties that have prototype property and no initializer', function() {
+                function dec(target, name, descriptor){
+
+                }
+
+                class Example {
+                    @dec prop;
+                }
+                Example.prototype.prop = 123;
+
+                let inst = new Example();
+                expect(inst).to.have.ownProperty('prop');
+                expect(inst.prop).to.eql(123);
+                Example.prototype.prop = 234;
+                expect(inst.prop).to.eql(123);
+                expect(Object.getOwnPropertyDescriptor(inst, 'prop').writable).to.be.true;
             });
 
             it('should support mutating an initialzer into an accessor', function(){


### PR DESCRIPTION
Currently class properties with no initializer are set as `null` and un-`writable`, which is problematic especially for Angular 2 apps that utilize decorators often.

``` js
class SomeComponent {
  @Input() prop;
}
```

According to [the ES Class Fields and Static Properties proposal](https://github.com/jeffmo/es-class-fields-and-static-properties#instance-field-declaration-process), **no initializer** should be treated as an initializer with `this.prop`.
