### PR TITLE
Allow getter and setter for class properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-decorators-legacy",
   "description": "A plugin for Babel 6 that (mostly) replicates the old decorator behavior from Babel 5.",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "main": "lib",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -33,13 +33,19 @@ const buildInitializerWarningHelper = template(`
 const buildInitializerDefineProperty = template(`
     function NAME(target, property, descriptor, context){
         if (!descriptor) return;
-
-        Object.defineProperty(target, property, {
-            enumerable: descriptor.enumerable,
-            configurable: descriptor.configurable,
-            writable: descriptor.writable,
-            value: descriptor.initializer ? descriptor.initializer.call(context) : void 0,
-        });
+        const desc = {
+          enumerable: descriptor.enumerable,
+          configurable: descriptor.configurable,
+          writable: descriptor.writable
+        };
+        if (descriptor.initializer) {
+          desc.value = descriptor.initializer ? descriptor.initializer.call(context) : void 0;
+        } else {
+          desc.get = descriptor.get;
+          desc.set = descriptor.set;
+          delete desc.writable;
+        }
+        Object.defineProperty(target, property, desc);
     }
 `);
 


### PR DESCRIPTION
`get` and `set` in descriptor returned by a decorator will not be used for class properties.

This commit will handle `get` and `set` for class properties with decorators.
