### PR TITLE
Add warning about plugin order

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ Add the following line to your .babelrc file:
     {
         "plugins": ["babel-plugin-transform-decorators-legacy"]
     }
+    
+#### NOTE: Order of Plugins Matters!
+If you are including your plugins manually and using `transform-class-properties`, make sure that `transform-decorators-legacy` comes *before* `transform-class-properties`.
+
+```js
+/// WRONG
+
+"plugins": [
+  "transform-class-properties",
+  "transform-decorators-legacy"
+]
+
+// RIGHT
+
+"plugins": [
+  "transform-decorators-legacy",
+  "transform-class-properties"
+]
+```
 
 ## Why "legacy"?
 


### PR DESCRIPTION
I spent literally the last 5 hours trying to figure out why my code wasn't working, discovering that the transpiled output was incorrect, writing tests for this repo that passed, etc basically tried everything in the book only to discover that the issue was the order in which I specified my babel plugins.

``` js
// WRONG!!

"plugins": [
  "transform-class-properties",
  "transform-decorators-legacy"
]

// RIGHT

"plugins": [
  "transform-decorators-legacy",
  "transform-class-properties"
]
```

Perhaps adding a warning like this PR (or similar) will save others a ton of headaches.

While I had searched for similar issues, for some reason I missed #30 which is the same problem. Feel free to disagree, but boy was this frustrating.
