### PR TITLE
fix(property-decorator): set configurable=true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -234,6 +234,7 @@ export default function({types: t}){
                         t.arrayExpression(decorators.map(dec => dec.expression)),
                         t.objectExpression([
                             t.objectProperty(t.identifier('enumerable'), t.booleanLiteral(true)),
+                            t.objectProperty(t.identifier('configurable'), t.booleanLiteral(true)),
                             t.objectProperty(t.identifier('initializer'), initializer),
                         ]),
                     ])),


### PR DESCRIPTION
current version leaves the property non-configurable.this prevents aurelia from observing the property
see https://github.com/SpoonX/aurelia-orm/issues/177
see https://github.com/aurelia/framework/issues/541
