### PR TITLE
Fix for static properties that are instance of the container class.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1141,6 +1141,29 @@ describe('decorators', function(){
                 expect(descs._.configurable).to.be.false;
                 expect(Example._).to.eql('__8__');
             });
+
+            it('should support being an instance of the decorated container class', function() {
+                function dec() {
+
+                }
+
+                @dec
+                class Example {
+                    static prop = new Example();
+                }
+
+                expect(Example).to.have.ownProperty('prop');
+                expect(Example.prop).to.be.an.instanceof(Example);
+            });
+
+            it('should support being an instance of the undecorated container class', function() {
+                class Example {
+                    static prop = new Example();
+                }
+
+                expect(Example).to.have.ownProperty('prop');
+                expect(Example.prop).to.be.an.instanceof(Example);
+            });
         });
     });
 


### PR DESCRIPTION
Trying to create singleton class with static property with instance of the container class will fail due to incorrect transformations:
```javascript
class Foo {
    static instance = new Foo();
}
```
will become:
```javascript
let Foo = class Foo {
    static instance = new Foo(); // Here Foo is not a constructor
}
```