### PR TITLE
Replace .slice().reverse().reduce() with .reduceRight

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ const buildApplyDecoratedDescriptor = template(`
             desc.writable = true;
         }
 
-        desc = decorators.slice().reverse().reduce(function(desc, decorator){
+        desc = decorators.reduceRight(function(desc, decorator){
             return decorator(target, property, desc) || desc;
         }, desc);
 


### PR DESCRIPTION
Same semantics but doesn't need to copy the array or reverse it