### PR TITLE
 Adding support for getter/setter descriptors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-decorators-legacy",
   "description": "A plugin for Babel 6 that (mostly) replicates the old decorator behavior from Babel 5.",
-  "version": "1.4.1",
+  "version": "1.3.4",
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "main": "lib",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-transform-decorators-legacy",
   "description": "A plugin for Babel 6 that (mostly) replicates the old decorator behavior from Babel 5.",
-  "version": "1.3.4",
+  "version": "1.4.1",
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "main": "lib",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -34,16 +34,14 @@ const buildInitializerDefineProperty = template(`
     function NAME(target, property, descriptor, context){
         if (!descriptor) return;
 
-        var value = descriptor.initializer ? descriptor.initializer.call(context) : void 0;
-        if (descriptor.get || descriptor.set) {
-            Object.defineProperty(target, property, descriptor);
-        } else {
-            Object.defineProperty(target, property, {
-                enumerable: descriptor.enumerable,
-                configurable: descriptor.configurable,
-                writable: descriptor.writable,
-                value: value,
-            });
+        var initializer = descriptor.initializer;
+        if (initializer && !(descriptor.set || descriptor.get)) {
+            descriptor.value = initializer.call(context);
+        }
+        
+        Object.defineProperty(target, property, descriptor);
+        if (initializer && descriptor.set) {
+            target[property] = initializer.call(context);
         }
     }
 `);

--- a/src/index.js
+++ b/src/index.js
@@ -34,12 +34,17 @@ const buildInitializerDefineProperty = template(`
     function NAME(target, property, descriptor, context){
         if (!descriptor) return;
 
-        Object.defineProperty(target, property, {
-            enumerable: descriptor.enumerable,
-            configurable: descriptor.configurable,
-            writable: descriptor.writable,
-            value: descriptor.initializer ? descriptor.initializer.call(context) : void 0,
-        });
+        var value = descriptor.initializer ? descriptor.initializer.call(context) : void 0;
+        if (descriptor.get || descriptor.set) {
+            Object.defineProperty(target, property, descriptor);
+        } else {
+            Object.defineProperty(target, property, {
+                enumerable: descriptor.enumerable,
+                configurable: descriptor.configurable,
+                writable: descriptor.writable,
+                value: value,
+            });
+        }
     }
 `);
 


### PR DESCRIPTION
One more try :-)

Currently only descriptors with writable/value pairs are supported. This PR will add support for descriptors with getter/setter pairs. 

Since these descriptor were never supported, this change will not add any regression and only add missing functionality.

I hope this upgrade makes it into the repo. All the best :-)