### PR TITLE
clearing decorators array on methods even if no decorators are found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,11 +171,20 @@ export default function({types: t}){
      * with the proper decorated behavior.
      */
     function applyMethodDecorators(path, state){
-        const hasMethodDecorators = path.node.body.body.some(function(node){
-            return (node.decorators || []).length > 0;
+        const nodesWithDecoratorArray = path.node.body.body.filter(function(node) {
+            return Boolean(node.decorators);
+        });
+        const hasMethodDecorators = nodesWithDecoratorArray.some(function(node){
+            return node.decorators.length > 0;
         });
 
-        if (!hasMethodDecorators) return;
+        if (!hasMethodDecorators) {
+          // need to nullify decorators property for Babel 6 to not throw
+          nodesWithDecoratorArray.forEach(function(node) {
+            node.decorators = null;
+          });
+          return;
+        };
 
         return applyTargetDecorators(path, state, path.node.body.body);
     }
@@ -185,11 +194,20 @@ export default function({types: t}){
      * with the proper decorated behavior.
      */
     function applyObjectDecorators(path, state){
-        const hasMethodDecorators = path.node.properties.some(function(node){
-            return (node.decorators || []).length > 0;
+        const nodesWithDecoratorArray = path.node.properties.filter(function(node) {
+            return Boolean(node.decorators);
+        });
+        const hasMethodDecorators = nodesWithDecoratorArray.some(function(node){
+            return node.decorators.length > 0;
         });
 
-        if (!hasMethodDecorators) return;
+        if (!hasMethodDecorators) {
+          // need to nullify decorators property for Babel 6 to not throw
+          nodesWithDecoratorArray.forEach(function(node) {
+            node.decorators = null;
+          });
+          return;
+        }
 
         return applyTargetDecorators(path, state, path.node.properties);
     }


### PR DESCRIPTION
Got bitten by this when developing babel-plugin-undecorate:
https://www.npmjs.com/package/babel-plugin-undecorate

See corresponding comment here:
https://github.com/sirrodgepodge/babel-plugin-undecorate/blob/master/index.js#L50

There's a devious (apparently quite edge-y) case that's wasn't covered by this lib where none of a class's methods have decorators but one or more does have an empty array in the "decorators" property.

If this case occurs, `applyTargetDecorators`won't be run on this method, which means that this `decorators` property will not get set to `null` (it will remain an empty array).  

This means that if using Babel 6 (which many do since Babel 7 is still beta) "babel-plugin-transform-decorators" is then run subsequently (as it will be with the common `babel-preset-stage-0`) it will throw due to this check (arguably a bug there that there's no empty array check): https://github.com/babel/babel/blob/6.x/packages/babel-plugin-transform-decorators/src/index.js#L55

The code in this PR fixes this by clearing the `decorators` empty arrays on each method even if no actual decorators are found.

I'd add a UT but I'm afraid I would kinda need to disrupt the whole way you've been running tests as the only way that I know how to replicate is by modifying AST with another babel-plugin.